### PR TITLE
proposed RFC-1, separate introductions

### DIFF
--- a/community/RFCs.md
+++ b/community/RFCs.md
@@ -20,6 +20,9 @@ The Underlay maintains a RFC (Request for Comments) series to document our ideas
 [**About the Underlay**](https://www.underlay.org/pub/tdefqg1q)
 <br/>*Sept 25, 2019 · Joel Gustafson, Samuel Klein, Danny Hillis, Travis Rich, and Gabriel Stein*
 
+[**Data and Model Sharing**](https://www.underlay.org/pub/data-sharing-questions/release/4)
+<br/>*Sept 14, 2019 · Samuel Klein*
+
 [**The Future of Knowledge**](https://www.underlay.org/pub/future)
 <br/>*Jul 18, 2018 · Danny Hillis, Samuel Klein, and Travis Rich*
 

--- a/community/RFCs.md
+++ b/community/RFCs.md
@@ -5,28 +5,33 @@ The Underlay maintains a RFC (Request for Comments) series to document our ideas
 [**RFC 0: Underlay RFCs**](https://www.underlay.org/pub/urfcs/release/1)
 <br/>*Aug 2, 2020 · Danny Hillis*
 
-## Historical RFCs
+[**RFC 1: Content-Addressing Semantic Data**](https://notes.knowledgefutures.org/pub/ic0grz58)
+<br/>*Aug 31, 2019 · Joel Gustafson*  
 
-[**RFC -1: Open Research Questions (2019)**](https://www.underlay.org/pub/research-questions)
+
+## Drafts and historical documents
+
+[**Open Research Questions (2019)**](https://www.underlay.org/pub/research-questions)
 <br/>*Nov 26, 2019 · Joel Gustafson*
 
-[**RFC -2: Content-Addressing Semantic Data**](https://notes.knowledgefutures.org/pub/ic0grz58)
+[**Content-Addressing Semantic Data**](https://notes.knowledgefutures.org/pub/ic0grz58)
 <br/>*Oct 24, 2019 · Joel Gustafson*
 
-[**RFC -3: About the Underlay**](https://www.underlay.org/pub/tdefqg1q)
+[**About the Underlay**](https://www.underlay.org/pub/tdefqg1q)
 <br/>*Sept 25, 2019 · Joel Gustafson, Samuel Klein, Danny Hillis, Travis Rich, and Gabriel Stein*
 
-[**RFC -4: The Future of Knowledge**](https://www.underlay.org/pub/future)
+[**The Future of Knowledge**](https://www.underlay.org/pub/future)
 <br/>*Jul 18, 2018 · Danny Hillis, Samuel Klein, and Travis Rich*
 
-[**RFC -5: Patterns for Crystallizing Knowledge**](https://www.underlay.org/pub/up)
+[**Patterns for Crystallizing Knowledge**](https://www.underlay.org/pub/up)
 <br/>*Jul 9, 2018 · Samuel Klein*
 
 
 ## Introductions to the Underlay
 
-[**A short introduction**](https://www.underlay.org/pub/short-intro)
-<br/>*Jul 2, 2020 · Danny Hillis*
+[**About the Underlay**](https://www.underlay.org/pub/tdefqg1q)  |  [**A short introduction**](https://www.underlay.org/pub/short-intro)
 
-[**A first description**](https://underlay.mit.edu)
+[**First Underlay site**](https://underlay.mit.edu)
 <br/>*Mar 22, 2018 · Danny Hillis, Samuel Klein, and Travis Rich*
+
+


### PR DESCRIPTION
Example of a draft that becomes an RFC (content-addressing semantic data). 
RFCs are timestamped w/ their publication date; drafts should indicate their last-update date.

Introductions and presentations about the project deserve a separate _Introductions.md_, each with a date + context/audience.